### PR TITLE
clap args parsing, scripts are handled uniquely by canonical path and…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,10 @@ name = "rustic"
 version = "0.0.0"
 
 [dependencies]
-env_logger = "*"
-log = "*"
+env_logger = "~ 0.3"
+log = "~ 0.3"
+clap = "~ 1.5"
+sha1 = "0.1.1"
 
 [dependencies.lines]
 git = "https://github.com/japaric/lines.rs"


### PR DESCRIPTION
Hi,

Here I made three changes:
1. using SHA1 digest of directory path for cache entry name to avoid name collisions
2. using clap for argument parsing and help message
3. using more specific versions in Cargo.toml as required for crates.io

I needed them for better usability so I share them with you here.
Sorry for coupling them all together, please feel free to choose and pick.
This could be nice crates.io package since install command is now supported :)

Best regards,
Jakub